### PR TITLE
added uuid basetype to ArgumentParser

### DIFF
--- a/ficum-parser/src/test/java/de/bitgrip/ficum/parser/ArgumentParserTest.java
+++ b/ficum-parser/src/test/java/de/bitgrip/ficum/parser/ArgumentParserTest.java
@@ -3,6 +3,7 @@ package de.bitgrip.ficum.parser;
 import java.io.UnsupportedEncodingException;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.UUID;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -405,6 +406,30 @@ public class ArgumentParserTest {
         String input = "''";
 
         assertValue(expected, input);
+    }
+
+    @Test()
+    public void testPositive_uuid() {
+        final UUID expected = UUID.randomUUID();
+        String input = expected.toString();
+
+        assertValue(expected, input);
+    }
+
+    @Test()
+    public void testError_uppercase_uuid() {
+        final UUID expected = UUID.randomUUID();
+        String input = expected.toString().toUpperCase();
+
+        assertError(InvalidInputError.class, input);
+    }
+
+    @Test()
+    public void testError_invalid_uuid() {
+        final UUID expected = UUID.randomUUID();
+        String input = expected.toString()+"a";
+
+        assertError(InvalidInputError.class, input);
     }
 
     @Test()

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
@@ -58,6 +58,7 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
     mappedTypes.add(Calendar.class);
     mappedTypes.add(ReadablePartial.class);
     mappedTypes.add(ReadableInstant.class);
+    mappedTypes.add(UUID.class);
   }
 
   private static boolean containsEscapedChar(String value) {


### PR DESCRIPTION
extended parser for supporting UUID 4 string representation as baseType (https://www.itu.int/rec/T-REC-X.667/en https://tools.ietf.org/html/rfc4122
- UUID only support hexDigits in lower case