### PR TITLE
added enum and other type support in arrays for JPAPredicateVisitor

### DIFF
--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
@@ -331,7 +331,7 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
                     : doBuildPredicate(node.getComparison(), path.as(clazz), value);
 
         } else if (argument instanceof List) {
-            //transform all values to their correct types
+            //convert all values to the supported data-type
             List<Comparable<?>> transformedValues = ((List<Comparable<?>>) argument).stream().map(v -> convertValue(v, clazz)).collect(Collectors.toList());
             pred = doBuildPredicate(node.getComparison(), path.as(clazz), sanatizeToComparable(transformedValues));
         } else if (argument == null) {

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
 
@@ -272,6 +273,39 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
         return false;
     }
 
+    private Comparable<?> convertValue(Comparable<?> value,  Class<? extends Comparable> clazz ){
+        // convert from string to enum
+        if (value instanceof String && clazz.isEnum()) {
+            value = Enum.valueOf((Class<? extends Enum>) clazz, value.toString());
+        }
+
+        // convert date and time types
+        if (value instanceof LocalDate && clazz.isAssignableFrom(Date.class)) {
+            value = Date.from(((LocalDate) value).atStartOfDay()
+                    .atZone(ZoneId.of("UTC"))
+                    .toInstant());
+        }
+
+        if (value instanceof LocalDate && clazz.isAssignableFrom(Calendar.class)) {
+            value = GregorianCalendar.from(((LocalDate) value).atStartOfDay()
+                    .atZone(ZoneId.of("UTC")));
+        }
+
+        if (value instanceof LocalDate && clazz.isAssignableFrom(OffsetDateTime.class)) {
+            value = OffsetDateTime.from(((LocalDate) value).atStartOfDay()
+                    .atZone(ZoneId.of("UTC")));
+        }
+
+        if (value instanceof OffsetDateTime && clazz.isAssignableFrom(Date.class)) {
+            value = Date.from(((OffsetDateTime) value).toInstant());
+        }
+
+        if (value instanceof OffsetDateTime && clazz.isAssignableFrom(Calendar.class)) {
+            value = GregorianCalendar.from(((OffsetDateTime) value).toZonedDateTime());
+        }
+        return value;
+    }
+
     public Predicate start(Node node) {
         predicates = new ArrayList<>();
         node.accept(this);
@@ -290,42 +324,16 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
         if (argument instanceof Comparable<?>) {
             Comparable<?> value = (Comparable<?>) argument;
 
-            // convert from string to enum
-            if (value instanceof String && clazz.isEnum()) {
-                value = Enum.valueOf((Class<? extends Enum>) clazz, value.toString());
-            }
-
-            // convert date and time types
-            if (value instanceof LocalDate && clazz.isAssignableFrom(Date.class)) {
-                value = Date.from(((LocalDate) value).atStartOfDay()
-                        .atZone(ZoneId.of("UTC"))
-                        .toInstant());
-            }
-
-            if (value instanceof LocalDate && clazz.isAssignableFrom(Calendar.class)) {
-                value = GregorianCalendar.from(((LocalDate) value).atStartOfDay()
-                        .atZone(ZoneId.of("UTC")));
-            }
-
-            if (value instanceof LocalDate && clazz.isAssignableFrom(OffsetDateTime.class)) {
-                value = OffsetDateTime.from(((LocalDate) value).atStartOfDay()
-                        .atZone(ZoneId.of("UTC")));
-            }
-
-            if (value instanceof OffsetDateTime && clazz.isAssignableFrom(Date.class)) {
-                value = Date.from(((OffsetDateTime) value).toInstant());
-            }
-
-            if (value instanceof OffsetDateTime && clazz.isAssignableFrom(Calendar.class)) {
-                value = GregorianCalendar.from(((OffsetDateTime) value).toZonedDateTime());
-            }
+            value = convertValue(value,clazz);
 
             pred = isCollectionSizeCheck(path, value)
                     ? doBuildCollectionSizePredicate(node.getComparison(), path, (Integer) value)
                     : doBuildPredicate(node.getComparison(), path.as(clazz), value);
 
         } else if (argument instanceof List) {
-            pred = doBuildPredicate(node.getComparison(), path.as(clazz), sanatizeToComparable((List) argument));
+            //transform all values to their correct types
+            List<Comparable<?>> transformedValues = ((List<Comparable<?>>) argument).stream().map(v -> convertValue(v, clazz)).collect(Collectors.toList());
+            pred = doBuildPredicate(node.getComparison(), path.as(clazz), sanatizeToComparable(transformedValues));
         } else if (argument == null) {
             pred = doBuildPredicate(node.getComparison(), path.as(clazz), (Comparable<?>) null);
         } else {

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
@@ -244,6 +244,8 @@ public class JPAPredicateVisitorTest {
         Assert.assertEquals(2, results.size());
     }
 
+
+
     @Test
     public void testNestedTimestamp() {
         OffsetDateTime dateTime = OffsetDateTime.of(2013, 1, 4,
@@ -301,6 +303,19 @@ public class JPAPredicateVisitorTest {
         List<Pet> results = query.getResultList();
 
         Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testInPredicateWithNestedEnum() {
+        String input = "visits.type=in=['SCHEDULED','EMERGENCY']";
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+
+        Predicate predicate = petVisitor.start(node);
+        TypedQuery<Pet> query = getTypedQuery(predicate);
+
+        List<Pet> results = query.getResultList();
+
+        Assert.assertEquals(3, results.size());
     }
 
     @Test

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
@@ -244,8 +244,6 @@ public class JPAPredicateVisitorTest {
         Assert.assertEquals(2, results.size());
     }
 
-
-
     @Test
     public void testNestedTimestamp() {
         OffsetDateTime dateTime = OffsetDateTime.of(2013, 1, 4,

--- a/ficum-visitor/src/test/resources/db/hsqldb/populateDB.sql
+++ b/ficum-visitor/src/test/resources/db/hsqldb/populateDB.sql
@@ -55,3 +55,4 @@ INSERT INTO visits VALUES (1, 7, '2013-01-01 15:45:00', 'rabies shot _', 'SCHEDU
 INSERT INTO visits VALUES (2, 8, '2013-01-02 11:30:00', 'rabies shot', 'SCHEDULED');
 INSERT INTO visits VALUES (3, 8, '2013-01-03 16:00:00', 'neutered', 'SCHEDULED');
 INSERT INTO visits VALUES (4, 7, '2013-01-04 09:15:00', 'car incident', 'EMERGENCY');
+INSERT INTO visits VALUES (5, 9, '2013-01-03 16:00:00', 'car incident', 'EMERGENCY');


### PR DESCRIPTION
with that feature, it is possible to use enumerations and other types as args in an array argument for JPAPredicateVisitor.

- extracted the value conversion to a private method which should be reused
- value conversion is done for every value in the array
- added unit test for inPredicate and enumerations, including added testdata