### PR TITLE
fixing-multi-thread-safety in ParseHelper

### DIFF
--- a/ficum-node/pom.xml
+++ b/ficum-node/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>de.bitgrip.ficum</groupId>
 		<artifactId>ficum</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
+    <version>0.10.1-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/ficum-parser/pom.xml
+++ b/ficum-parser/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>de.bitgrip.ficum</groupId>
     <artifactId>ficum</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.10.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/ficum-parser/src/main/java/de/bitgrip/ficum/parser/ParseHelper.java
+++ b/ficum-parser/src/main/java/de/bitgrip/ficum/parser/ParseHelper.java
@@ -1,5 +1,6 @@
 package de.bitgrip.ficum.parser;
 
+import java.util.Arrays;
 import java.util.Deque;
 
 import org.parboiled.Parboiled;
@@ -16,7 +17,7 @@ public class ParseHelper {
     }
 
     public static final Node parse(String query, String... allowedSelectorNames) {
-        ExpressionParser parser = Parboiled.createParser(ExpressionParser.class, (Object) allowedSelectorNames);
+        ExpressionParser parser = Parboiled.createParser(ExpressionParser.class, (Object) Arrays.copyOf(allowedSelectorNames, allowedSelectorNames.length));
         ReportingParseRunner<Deque<Object>> parseRunner = new ReportingParseRunner<Deque<Object>>(parser.root());
         ParsingResult<Deque<Object>> result = parseRunner.run(query);
 

--- a/ficum-visitor/pom.xml
+++ b/ficum-visitor/pom.xml
@@ -3,7 +3,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ficum-visitor</artifactId>
-  <version>0.11.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>FICUM - Visitors</name>
 
@@ -14,14 +13,14 @@
     <parent>
         <groupId>de.bitgrip.ficum</groupId>
         <artifactId>ficum</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.10.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>de.bitgrip.ficum</groupId>
             <artifactId>ficum-parser</artifactId>
-            <version>0.11.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.bitgrip.ficum</groupId>
   <artifactId>ficum</artifactId>
-  <version>0.11.0-SNAPSHOT</version>
+  <version>0.10.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>FICUM - Dynamic Filters</name>


### PR DESCRIPTION
additionally set version to 0.10.1-SNAPSHOT for a fix version