### PR TITLE
Fixed bug in visitors: Predicates/Filters of the LHS of a node were r…

### DIFF
--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitor.java
@@ -137,28 +137,31 @@ public class HazelcastPredicateVisitor extends AbstractVisitor<Predicate<?, ?>> 
         node.getRight().accept(this);
 
         Predicate<?, ?> pred = null;
+        Predicate<?, ?> leftHandSide = filters.get(filters.size() - 2);
+        Predicate<?, ?> rightHandSide = filters.get(filters.size() - 1);
         switch (node.getOperator()) {
             case AND:
-                pred = Predicates.and(filters.get(0), filters.get(1));
+                pred = Predicates.and(leftHandSide, rightHandSide);
                 break;
 
             case OR:
-                pred = Predicates.or(filters.get(0), filters.get(1));
+                pred = Predicates.or(leftHandSide, rightHandSide);
                 break;
 
             case NAND:
-                pred = Predicates.or(Predicates.not(filters.get(0)), Predicates.not(filters.get(1)));
+                pred = Predicates.or(Predicates.not(leftHandSide), Predicates.not(rightHandSide));
                 break;
 
             case NOR:
-                pred = Predicates.and(Predicates.not(filters.get(0)), Predicates.not(filters.get(1)));
+                pred = Predicates.and(Predicates.not(leftHandSide), Predicates.not(rightHandSide));
                 break;
 
             default:
                 throw new IllegalArgumentException("OperationNode: " + node + " does not resolve to a operation");
         }
 
-        filters.clear();
+        filters.remove(leftHandSide);
+        filters.remove(rightHandSide);
         filters.add(pred);
     }
 

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
@@ -353,28 +353,31 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
         node.getRight().accept(this);
 
         Predicate pred = null;
+        Predicate leftHandSide = predicates.get(predicates.size() - 2);
+        Predicate rightHandSide = predicates.get(predicates.size() - 1);
         switch (node.getOperator()) {
             case AND:
-                pred = criteriaBuilder.and(predicates.get(0), predicates.get(1));
+                pred = criteriaBuilder.and(leftHandSide, rightHandSide);
                 break;
 
             case OR:
-                pred = criteriaBuilder.or(predicates.get(0), predicates.get(1));
+                pred = criteriaBuilder.or(leftHandSide, rightHandSide);
                 break;
 
             case NAND:
-                pred = criteriaBuilder.or(criteriaBuilder.not(predicates.get(0)), criteriaBuilder.not(predicates.get(1)));
+                pred = criteriaBuilder.or(criteriaBuilder.not(leftHandSide), criteriaBuilder.not(rightHandSide));
                 break;
 
             case NOR:
-                pred = criteriaBuilder.and(criteriaBuilder.not(predicates.get(0)), criteriaBuilder.not(predicates.get(1)));
+                pred = criteriaBuilder.and(criteriaBuilder.not(leftHandSide), criteriaBuilder.not(rightHandSide));
                 break;
 
             default:
                 throw new IllegalArgumentException("OperationNode: " + node + " does not resolve to a operation");
         }
 
-        predicates.clear();
+        predicates.remove(leftHandSide);
+        predicates.remove(rightHandSide);
         predicates.add(pred);
     }
 

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitor.java
@@ -215,28 +215,31 @@ public class MongoDBFilterVisitor extends AbstractVisitor<Bson> {
         node.getRight().accept(this);
 
         Bson pred = null;
+        Bson leftHandSide = filters.get(filters.size() - 2);
+        Bson rightHandSide = filters.get(filters.size() - 1);
         switch (node.getOperator()) {
             case AND:
-                pred = Filters.and(filters.get(0), filters.get(1));
+                pred = Filters.and(leftHandSide, rightHandSide);
                 break;
 
             case OR:
-                pred = Filters.or(filters.get(0), filters.get(1));
+                pred = Filters.or(leftHandSide, rightHandSide);
                 break;
 
             case NAND:
-                pred = Filters.or(Filters.not(filters.get(0)), Filters.not(filters.get(1)));
+                pred = Filters.or(Filters.not(leftHandSide), Filters.not(rightHandSide));
                 break;
 
             case NOR:
-                pred = Filters.and(Filters.not(filters.get(0)), Filters.not(filters.get(1)));
+                pred = Filters.and(Filters.not(leftHandSide), Filters.not(rightHandSide));
                 break;
 
             default:
                 throw new IllegalArgumentException("OperationNode: " + node + " does not resolve to a operation");
         }
 
-        filters.clear();
+        filters.remove(leftHandSide);
+        filters.remove(rightHandSide);
         filters.add(pred);
     }
 

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitorTest.java
@@ -113,6 +113,26 @@ public class HazelcastPredicateVisitorTest {
     }
 
     @Test
+    public void testAndPredicateConcatenation() {
+        String input = "borough=='Manhattan',address.street=='11 Avenue',name=='Mcquaids Public House'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Predicate<?, ?> query = visitor.start(node);
+
+        Assert.assertEquals(1, getMap().values(query).size());
+    }
+
+    @Test
+    public void testAndPredicateOrPredicateConcatenation() {
+        String input = "borough=='Manhattan',address.street=='11 Avenue';address.street=='East   74 Street',name=='Glorious Food'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Predicate<?, ?> query = visitor.start(node);
+
+        Assert.assertEquals(3, getMap().values(query).size());
+    }
+
+    @Test
     public void testDatePredicate() {
         String input = "grade.date=ge=2015-01-01,grade.score=gt=1";
 

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
@@ -68,6 +68,20 @@ public class JPAPredicateVisitorTest {
     }
 
     @Test
+    public void testAndPredicateWithThreeCriteria() {
+        String input = "name=='Chuck',owner.firstName=='Jeff',visits.type=='EMERGENCY'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+
+        Predicate predicate = petVisitor.start(node);
+        TypedQuery<Pet> query = getTypedQuery(predicate);
+
+        List<Pet> results = query.getResultList();
+
+        Assert.assertEquals(1, results.size());
+    }
+
+    @Test
     public void testCollectionCount() {
         String input = "visits=ge=2";
         Node node = ParseHelper.parse(input, allowedSelectorNames);
@@ -278,6 +292,20 @@ public class JPAPredicateVisitorTest {
     @Test
     public void testOrPredicate() {
         String input = "name=='Leo';owner.firstName=='Jeff'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+
+        Predicate predicate = petVisitor.start(node);
+        TypedQuery<Pet> query = getTypedQuery(predicate);
+
+        List<Pet> results = query.getResultList();
+
+        Assert.assertEquals(2, results.size());
+    }
+
+    @Test
+    public void testAndPredicateCombinedWithOrPredicate() {
+        String input = "name=='Chuck';owner.firstName=='Jean',visits.type=='EMERGENCY'";
 
         Node node = ParseHelper.parse(input, allowedSelectorNames);
 

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitorTest.java
@@ -94,6 +94,26 @@ public class MongoDBFilterVisitorTest {
     }
 
     @Test
+    public void testAndPredicateConcatenation() {
+        String input = "borough=='Manhattan',address.street=='11 Avenue',name=='Mcquaids Public House'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Bson query = visitor.start(node);
+
+        Assert.assertEquals(1, getCollection(db).countDocuments(query));
+    }
+
+    @Test
+    public void testAndPredicateOrPredicateConcatenation() {
+        String input = "borough=='Manhattan',address.street=='11 Avenue';address.street=='East   74 Street',name=='Glorious Food'";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Bson query = visitor.start(node);
+
+        Assert.assertEquals(3, getCollection(db).countDocuments(query));
+    }
+
+    @Test
     public void testDatePredicate() {
         String input = "grades.date=ge=2015-01-01,grades.score=lt=1";
 


### PR DESCRIPTION
`filters`/`predicates` list is shared for all nested calls of `accept()`, which is why filters/predicates of the LHS of a node were unnecessarily removed when executing the `accept()` call of the RHS of a node, resulting in an Exception with more than 2 concatenated criteria.

Changing the type of `filters`/`predicates` to a stack or other LIFO structure might be useful.