### PR TITLE
Fix =in= and =nin= operators with single argument arrays

### DIFF
--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitor.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -70,6 +71,10 @@ public class HazelcastPredicateVisitor extends AbstractVisitor<Predicate<?, ?>> 
 
             case GREATER_EQUALS:
                 return Predicates.greaterEqual(fieldName, argument);
+
+            case IN:
+            case NIN:
+                return doBuildPredicate(comparison, fieldName, Collections.singletonList(argument));
 
             default:
                 return null;

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/JPAPredicateVisitor.java
@@ -161,6 +161,10 @@ public class JPAPredicateVisitor<T> extends AbstractVisitor<Predicate> {
             case GREATER_EQUALS:
                 return criteriaBuilder.greaterThanOrEqualTo(path, argument);
 
+            case IN:
+            case NIN:
+                return doBuildPredicate(comparison, path, Collections.singletonList(argument));
+
             default:
                 return null;
         }

--- a/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitor.java
+++ b/ficum-visitor/src/main/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitor.java
@@ -12,6 +12,7 @@ import org.bson.conversions.Bson;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -143,6 +144,9 @@ public class MongoDBFilterVisitor extends AbstractVisitor<Bson> {
             case GREATER_EQUALS:
                 return Filters.gte(fieldName, argument);
 
+            case IN:
+            case NIN:
+                return doBuildPredicate(comparison, fieldName, Collections.singletonList(argument));
             default:
                 return null;
         }

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/HazelcastPredicateVisitorTest.java
@@ -230,6 +230,16 @@ public class HazelcastPredicateVisitorTest {
     }
 
     @Test
+    public void testInPredicateSingletonList() {
+        String input = "borough=in=['Queens']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Predicate<?, ?> query = visitor.start(node);
+
+        Assert.assertEquals(987, getMap().values(query).size());
+    }
+
+    @Test
     public void testNinPredicate() {
         String input = "borough=nin=['Queens','Manhattan']";
 
@@ -237,6 +247,16 @@ public class HazelcastPredicateVisitorTest {
         Predicate<?, ?> query = visitor.start(node);
 
         Assert.assertEquals(1524, getMap().values(query).size());
+    }
+
+    @Test
+    public void testNinPredicateSingletonList() {
+        String input = "borough=nin=['Queens']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Predicate<?, ?> query = visitor.start(node);
+
+        Assert.assertEquals(4012, getMap().values(query).size());
     }
 
     @Test

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/JPAPredicateVisitorTest.java
@@ -332,6 +332,20 @@ public class JPAPredicateVisitorTest {
     }
 
     @Test
+    public void testInPredicateSingletonList() {
+        String input = "name=in=['Leo']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+
+        Predicate predicate = petVisitor.start(node);
+        TypedQuery<Pet> query = getTypedQuery(predicate);
+
+        List<Pet> results = query.getResultList();
+
+        Assert.assertEquals(1, results.size());
+    }
+
+    @Test
     public void testInPredicateWithNestedEnum() {
         String input = "visits.type=in=['SCHEDULED','EMERGENCY']";
         Node node = ParseHelper.parse(input, allowedSelectorNames);
@@ -356,6 +370,20 @@ public class JPAPredicateVisitorTest {
         List<Pet> results = query.getResultList();
 
         Assert.assertEquals(11, results.size());
+    }
+
+    @Test
+    public void testNinPredicateSingletonList() {
+        String input = "name=nin=['Leo']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+
+        Predicate predicate = petVisitor.start(node);
+        TypedQuery<Pet> query = getTypedQuery(predicate);
+
+        List<Pet> results = query.getResultList();
+
+        Assert.assertEquals(12, results.size());
     }
 
     @Test

--- a/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitorTest.java
+++ b/ficum-visitor/src/test/java/de/bitgrip/ficum/visitor/MongoDBFilterVisitorTest.java
@@ -319,6 +319,16 @@ public class MongoDBFilterVisitorTest {
     }
 
     @Test
+    public void testInPredicateSingletonList() {
+        String input = "borough=in=['Queens']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Bson query = visitor.start(node);
+
+        Assert.assertEquals(987, getCollection(db).countDocuments(query));
+    }
+
+    @Test
     public void testNinPredicate() {
         String input = "borough=nin=['Queens','Manhattan']";
 
@@ -326,6 +336,16 @@ public class MongoDBFilterVisitorTest {
         Bson query = visitor.start(node);
 
         Assert.assertEquals(1524, getCollection(db).countDocuments(query));
+    }
+
+    @Test
+    public void testNinPredicateSingletonList() {
+        String input = "borough=nin=['Queens']";
+
+        Node node = ParseHelper.parse(input, allowedSelectorNames);
+        Bson query = visitor.start(node);
+
+        Assert.assertEquals(4012, getCollection(db).countDocuments(query));
     }
 
     @Test


### PR DESCRIPTION
Single argument arrays are converted to plain argument values when parsing. All visitors did not support =in= and =nin= operators with plain arguments, causing an exception to be thrown for queries like `attribute=in=[123]`