### PR TITLE
Bump parboiled from version 1.3.1 to 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <dependency>
                 <groupId>org.parboiled</groupId>
                 <artifactId>parboiled-java</artifactId>
-                <version>1.3.1</version>
+                <version>1.4.1</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Purpose
Address Ficum issues with Java 17

How
Bump Parboiled to latest version as described in: https://github.com/sirthias/parboiled/issues/175

Checked locally under IntelliJ by forcing JDK 17 and 20, Maven 'Install' goal is successful.