### PR TITLE
release v0.13.1

### DIFF
--- a/ficum-annotation/pom.xml
+++ b/ficum-annotation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>de.bitgrip.ficum</groupId>
     <artifactId>ficum</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.13.1</version>
   </parent>
 
 </project>

--- a/ficum-node/pom.xml
+++ b/ficum-node/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>de.bitgrip.ficum</groupId>
 		<artifactId>ficum</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.13.1</version>
 	</parent>
 
 	<dependencies>

--- a/ficum-parser/pom.xml
+++ b/ficum-parser/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>de.bitgrip.ficum</groupId>
     <artifactId>ficum</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.13.1</version>
   </parent>
 
   <dependencies>

--- a/ficum-spring/pom.xml
+++ b/ficum-spring/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>de.bitgrip.ficum</groupId>
     <artifactId>ficum</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.13.1</version>
   </parent>
 
   <dependencies>

--- a/ficum-visitor/pom.xml
+++ b/ficum-visitor/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.bitgrip.ficum</groupId>
         <artifactId>ficum</artifactId>
-        <version>0.14.0-SNAPSHOT</version>
+        <version>0.13.1</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.bitgrip.ficum</groupId>
     <artifactId>ficum</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.14.1</version>
     <packaging>pom</packaging>
 
     <name>FICUM - Dynamic Filters</name>


### PR DESCRIPTION
Purpose
Release a new version of ficum compatible with java17.

Solution
Version bumped in parent and children pom files

cf. unreleased SNAPSHOT version: https://github.com/bitgrip/ficum/commit/51fedf8569c518cefe432d1bb4c5535258afa18a